### PR TITLE
Adding option to install the Chef Development Kit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ ifndef CM_VERSION
 endif
 # Packer does not allow empty variables, so only pass variables that are defined
 ifdef CM_VERSION
-	PACKER_VARS := -var 'cm=$(CM)' -var 'cm_version=$(CM_VERSION)'
+	PACKER_VARS := -var 'cm=$(CM)' -var 'cm_version=$(CM_VERSION)' -var 'cm_set_path=$(CM_SET_PATH)'
 else
-	PACKER_VARS := -var 'cm=$(CM)'
+	PACKER_VARS := -var 'cm=$(CM)' -var 'cm_set_path=$(CM_SET_PATH)'
 endif
 ifeq ($(CM),nocm)
 	BOX_SUFFIX := -$(CM).box
@@ -60,13 +60,13 @@ vmware/$(1): $(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 test-vmware/$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
-ssh-vmware/$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
+ssh-vmware/$(1): ssh-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 virtualbox/$(1): $(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 test-virtualbox/$(1): test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
-ssh-virtualbox/$(1): test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+ssh-virtualbox/$(1): ssh-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 $(1): vmware/$(1) virtualbox/$(1)
 

--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -38,6 +38,22 @@ install_chef()
     fi
 }
 
+install_chefdk()
+{
+    echo "==> Installing Chef Development Kit"
+    if [[ ${CM_VERSION:-} == 'latest' ]]; then
+        echo "==> Installing latest Chef version"
+        curl -L https://www.opscode.com/chef/install.sh | sh -s -- -P chefdk
+    else
+        echo "==> Installing Chef version ${CM_VERSION}"
+        curl -L https://www.opscode.com/chef/install.sh | sh -s -- -P chefdk -v ${CM_VERSION}
+    fi
+    if [[ ${CM_SET_PATH:-} == 'true' ]]; then
+      echo "Automatically setting vagrant PATH to Chef Client"
+      echo 'export PATH="/opt/chefdk/embedded/bin:$PATH"' >> /home/vagrant/.bash_profile
+    fi
+}
+
 install_salt()
 {
     echo "==> Installing Salt"
@@ -74,6 +90,10 @@ install_puppet()
 case "${CM}" in
   'chef')
     install_chef
+    ;;
+
+  'chefdk')
+    install_chefdk
     ;;
 
   'salt')


### PR DESCRIPTION
Tested with:
`make CM=chefdk CM_VERSION=latest CM_SET_PATH=true ssh-vmware/centos65`
`make CM=chefdk CM_VERSION=0.1.0 CM_SET_PATH=true ssh-vmware/centos65`
`make CM=chefdk CM_VERSION=latest ssh-vmware/centos65`
`make CM=chefdk CM_VERSION=0.1.0 ssh-vmware/centos65`
