### PR TITLE
Add missing UPDATE environment variable

### DIFF
--- a/centos70.json
+++ b/centos70.json
@@ -68,6 +68,7 @@
       "CM={{user `cm`}}",
       "CM_VERSION={{user `cm_version`}}",
       "CLEANUP_PAUSE={{user `cleanup_pause`}}",
+      "UPDATE={{user `update`}}",
       "http_proxy={{user `http_proxy`}}",
       "https_proxy={{user `https_proxy`}}",
       "ftp_proxy={{user `ftp_proxy`}}",


### PR DESCRIPTION
Very simple PR to add the missing UPDATE environment variable from centos70.json
