### PR TITLE
In 7.x EPEL, Docker package is called docker, not docker-io

### DIFF
--- a/script/docker.sh
+++ b/script/docker.sh
@@ -4,12 +4,13 @@ echo "==> Adding EPEL repo"
 cat /etc/redhat-release
 if grep -q -i "release 7" /etc/redhat-release ; then
     rpm -Uvh http://mirrors.mit.edu/epel/beta/7/x86_64/epel-release-7-0.2.noarch.rpm
+    echo "==> Installing docker"
+    yum install -y docker
 elif grep -q -i "release 6" /etc/redhat-release ; then
     rpm -Uvh http://fedora-epel.mirror.lstn.net/6/i386/epel-release-6-8.noarch.rpm
+    echo "==> Installing docker"
+    yum install -y docker-io
 fi
-
-echo "==> Installing docker"
-yum install -y docker-io
 
 echo "==> Starting docker"
 service docker start


### PR DESCRIPTION
Moving the docker install into the if/then conditional to pull "docker" on 7.x and "docker-io" on <7.x
