### PR TITLE
Enable VMWare 3D Acceleration on Centos 7 Desktop

### DIFF
--- a/tpl/vagrantfile-centos70-desktop.tpl
+++ b/tpl/vagrantfile-centos70-desktop.tpl
@@ -33,6 +33,7 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.enabled"] = "false"
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
     end
 
     config.vm.provider :vmware_workstation do |v, override|
@@ -44,5 +45,6 @@ Vagrant.configure("2") do |config|
         v.vmx["RemoteDisplay.vnc.enabled"] = "false"
         v.vmx["RemoteDisplay.vnc.port"] = "5900"
         v.vmx["scsi0.virtualDev"] = "lsilogic"
+        v.vmx["mks.enable3d"] = "TRUE"
     end
 end


### PR DESCRIPTION
The default CentOS 7 Desktop uses GNOME Shell 3 which requires 3D
acceleration to work smoothly. If 3D acceleration isn't enabled it falls
back to software-based rendering through LLVMpipe which is usable but
slow. Additionally, 3D Acceleration is enabled for VirtualBox guests
anyway.
