### PR TITLE
Support building Parallels boxes using packer 0.7.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,5 @@
 #
 Jeremy Rosengren <jeremy@rosengren.org>
 Mischa Taylor <mischa@misheska.com>
+Rickard von Essen <rickard.von.essen@gmail.com>
 Ross Smith II <ross@smithii.com>

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,20 @@ ifeq ($(CM),nocm)
 else
 	BOX_SUFFIX := -$(CM)$(CM_VERSION).box
 endif
-BUILDER_TYPES := vmware virtualbox
+BUILDER_TYPES := vmware virtualbox parallels
 TEMPLATE_FILENAMES := $(wildcard *.json)
 BOX_FILENAMES := $(TEMPLATE_FILENAMES:.json=$(BOX_SUFFIX))
 BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), box/$(builder)/$(box_filename)))
 TEST_BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), test-box/$(builder)/$(box_filename)))
 VMWARE_BOX_DIR := box/vmware
 VIRTUALBOX_BOX_DIR := box/virtualbox
+PARALLELS_BOX_DIR := box/parallels
 VMWARE_OUTPUT := output-vmware-iso
 VIRTUALBOX_OUTPUT := output-virtualbox-iso
+PARALLELS_OUTPUT := output-parallels-iso
 VMWARE_BUILDER := vmware-iso
 VIRTUALBOX_BUILDER := virtualbox-iso
+PARALLELS_BUILDER := parallels-iso
 CURRENT_DIR = $(shell pwd)
 SOURCES := script/fix-slow-dns.sh script/sshd.sh script/vagrant.sh script/vmtool.sh script/cmtool.sh script/cleanup.sh
 
@@ -74,9 +77,15 @@ test-virtualbox/$(1): test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 ssh-virtualbox/$(1): ssh-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
-$(1): vmware/$(1) virtualbox/$(1)
+parallels/$(1): $(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
-test-$(1): test-vmware/$(1) test-virtualbox/$(1)
+test-parallels/$(1): test-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+ssh-parallels/$(1): ssh-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+$(1): vmware/$(1) virtualbox/$(1) parallels/$(1)
+
+test-$(1): test-vmware/$(1) test-virtualbox/$(1) test-parallels/$(1)
 
 endef
 
@@ -167,7 +176,7 @@ $(VMWARE_BOX_DIR)/centos59-i386$(BOX_SUFFIX): centos59-i386.json $(SOURCES) http
 #	rm -rf output-virtualbox-iso
 #	mkdir -p $(VIRTUALBOX_BOX_DIR)
 #	packer build -only=virtualbox-iso $(PACKER_VARS) $<
-	
+
 $(VIRTUALBOX_BOX_DIR)/centos70$(BOX_SUFFIX): centos70.json $(SOURCES) http/ks7.cfg
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
@@ -238,8 +247,85 @@ $(VIRTUALBOX_BOX_DIR)/centos59-i386$(BOX_SUFFIX): centos59-i386.json $(SOURCES) 
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
 	packer build -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS59_I386)" $<
 
+# Generic rule - not used currently
+#$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): %.json
+#	cd $(dir $<)
+#	rm -rf output-parallels-iso
+#	mkdir -p $(PARALLELS_BOX_DIR)
+#	packer build -only=parallels-iso $(PACKER_VARS) $<
+
+$(PARALLELS_BOX_DIR)/centos70$(BOX_SUFFIX): centos70.json $(SOURCES) http/ks7.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS70_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos70-docker$(BOX_SUFFIX): centos70-docker.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS70_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos70-desktop$(BOX_SUFFIX): centos70-desktop.json $(SOURCES) http/ks7-desktop.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS70_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos65$(BOX_SUFFIX): centos65.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS65_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos65-desktop$(BOX_SUFFIX): centos65-desktop.json $(SOURCES) script/desktop.sh http/ks6-desktop.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS65_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos65-docker$(BOX_SUFFIX): centos65-docker.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS65_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos64$(BOX_SUFFIX): centos64.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS64_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos64-desktop$(BOX_SUFFIX): centos64-desktop.json $(SOURCES) script/desktop.sh http/ks6-desktop.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS64_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos510$(BOX_SUFFIX): centos510.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS510_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos59$(BOX_SUFFIX): centos59.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS59_X86_64)" $<
+
+$(PARALLELS_BOX_DIR)/centos65-i386$(BOX_SUFFIX): centos65-i386.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS65_I386)" $<
+
+$(PARALLELS_BOX_DIR)/centos64-i386$(BOX_SUFFIX): centos64-i386.json $(SOURCES) http/ks6.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS64_I386)" $<
+
+$(PARALLELS_BOX_DIR)/centos510-i386$(BOX_SUFFIX): centos510-i386.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS510_I386)" $<
+
+$(PARALLELS_BOX_DIR)/centos59-i386$(BOX_SUFFIX): centos59-i386.json $(SOURCES) http/ks5.cfg
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(CENTOS59_I386)" $<
+
 list:
-	@echo "Prepend 'vmware/' or 'virtualbox/' to build only one target platform:"
+	@echo "Prepend 'vmware/', 'virtualbox/', or 'parallels/' to build only one target platform:"
 	@echo "  make vmware/centos65"
 	@echo ""
 	@echo "Targets:"
@@ -254,7 +340,7 @@ validate:
 	done
 
 clean: clean-builders clean-output clean-packer-cache
-		
+
 clean-builders:
 	@for builder in $(BUILDER_TYPES) ; do \
 		if test -d box/$$builder ; then \
@@ -262,25 +348,31 @@ clean-builders:
 			find box/$$builder -maxdepth 1 -type f -name "*.box" ! -name .gitignore -exec rm '{}' \; ; \
 		fi ; \
 	done
-	
+
 clean-output:
 	@for builder in $(BUILDER_TYPES) ; do \
 		echo Deleting output-$$builder-iso ; \
 		echo rm -rf output-$$builder-iso ; \
 	done
-	
+
 clean-packer-cache:
 	echo Deleting packer_cache
 	rm -rf packer_cache
 
 test-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/test-box.sh $< vmware_desktop vmware_fusion $(CURRENT_DIR)/test/*_spec.rb || exit
-	
+
 test-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/test-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb || exit
-	
+
+test-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
+	bin/test-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb || exit
+
 ssh-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/ssh-box.sh $< vmware_desktop vmware_fusion $(CURRENT_DIR)/test/*_spec.rb
-	
+
 ssh-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
-	bin/ssh-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb	
+	bin/ssh-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb
+
+ssh-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
+	bin/ssh-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ using Packer.
 
 ## Building the Vagrant boxes
 
-To build all the boxes, you will need Packer and both VirtualBox and VMware Fusion
-installed.
+To build all the boxes, you will need Packer and both VirtualBox, VMware
+Fusion, and Parallels Desktop for Mac installed.
 
 A GNU Make `Makefile` drives the process via the following targets:
 
-    make        # Build all the box types (VirtualBox & VMware)
+    make        # Build all the box types (VirtualBox, VMware & Parallels)
     make test   # Run tests against all the boxes
     make list   # Print out individual targets
     make clean  # Clean up build detritus
@@ -51,14 +51,14 @@ process, should you be using a proxy:
 * ftp_proxy
 * rsync_proxy
 * no_proxy
-    
+
 ### Tests
 
 The tests are written in [Serverspec](http://serverspec.org) and require the
 `vagrant-serverspec` plugin to be installed with:
 
     vagrant plugin install vagrant-serverspec
-    
+
 The `Makefile` has individual targets for each box type with the prefix
 `test-*` should you wish to run tests individually for each box.
 
@@ -68,7 +68,7 @@ do exploratory testing.  For example, to do exploratory testing
 on the VirtualBox training environmnet, run the following command:
 
     make ssh-box/virtualbox/centos65-nocm.box
-    
+
 Upon logout `make ssh-*` will automatically de-register the box as well.
 
 ### Makefile.local override

--- a/centos510-i386.json
+++ b/centos510-i386.json
@@ -60,10 +60,32 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos510-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "centos",
+    "parallels_tools_flavor": "lin",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",
-    "environment_vars": [ 
+    "environment_vars": [
       "CM={{user `cm`}}",
       "CM_VERSION={{user `cm_version`}}",
       "CLEANUP_PAUSE={{user `cleanup_pause`}}",

--- a/centos510.json
+++ b/centos510.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos510",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "centos",
+    "parallels_tools_flavor": "lin",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos59-i386.json
+++ b/centos59-i386.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos59-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "centos",
+    "parallels_tools_flavor": "lin",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos59.json
+++ b/centos59.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos59",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "centos",
+    "parallels_tools_flavor": "lin",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks5.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos64-desktop.json
+++ b/centos64-desktop.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "1024"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos64",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6-desktop.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "1024"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos64-i386.json
+++ b/centos64-i386.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos64-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos64.json
+++ b/centos64.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos64",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos65-desktop.json
+++ b/centos65-desktop.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "1024"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos65-desktop",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6-desktop.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "1024"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos65-docker.json
+++ b/centos65-docker.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos65-docker",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos65-i386.json
+++ b/centos65-i386.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos65-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos65.json
+++ b/centos65.json
@@ -60,6 +60,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos65",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "centos",
+    "parallels_tools_flavor": "lin",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks6.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos70-desktop.json
+++ b/centos70-desktop.json
@@ -61,6 +61,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "1024"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos70-desktop",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7-desktop.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 40960,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "1024"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos70-docker.json
+++ b/centos70-docker.json
@@ -61,6 +61,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos70-docker",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "centos",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/centos70.json
+++ b/centos70.json
@@ -61,6 +61,28 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "centos70",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "centos",
+    "parallels_tools_flavor": "lin",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort}}/ks7.cfg<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/script/vmtool.sh
+++ b/script/vmtool.sh
@@ -92,5 +92,15 @@ if [[ $PACKER_BUILDER_TYPE =~ virtualbox ]]; then
     fi
 fi
 
+if [[ $PACKER_BUILDER_TYPE =~ parallels ]]; then
+    echo "==> Installing Parallels tools"
+
+    mount -o loop /home/vagrant/prl-tools-lin.iso /mnt
+    sh /mnt/install --install-unattended-with-deps
+    umount /mnt
+    rm -rf /home/vagrant/prl-tools-lin.iso
+    rm -f /home/vagrant/.prlctl_version
+fi
+
 echo "==> Removing packages needed for building guest tools"
 yum -y remove gcc cpp kernel-devel kernel-headers perl


### PR DESCRIPTION
Support building vagrant boxes for _Parallels Desktop for Mac_.

Requires Parallels Desktop 9+ and packer v 0.7.0.
